### PR TITLE
Fix Dart Sass deprecation warnings

### DIFF
--- a/css/_blog.scss
+++ b/css/_blog.scss
@@ -1,3 +1,6 @@
+@use "sass:math";
+@use "variables" as *;
+
 $avatar-width: 160px;
 $avatar-border-width: 8px;
 
@@ -22,7 +25,8 @@ $avatar-border-width: 8px;
 }
 
 .back-to-neppari {
-	@extend .header;
+	font-family: "Miso Regular", "Helvetica Neue", "Arial Light", "Arial", sans-serif;
+	line-height: 1.1em;
 	margin-top: 0;
 	padding: 0.2em 1em;
 
@@ -54,8 +58,10 @@ $avatar-border-width: 8px;
 	}
 
 	.tagline {
-		@extend .header;
-		@extend .h3;
+		font-family: "Miso Regular", "Helvetica Neue", "Arial Light", "Arial", sans-serif;
+		line-height: 1.1em;
+		margin-top: 1.5rem;
+		font-size: 1.25rem;
 	}
 }
 
@@ -97,7 +103,7 @@ p.first {
 		border: $avatar-border-width solid $accent-color;
 		width: $image-container-width;
 		height: $image-container-width;
-		border-radius: $image-container-width / 2;
+		border-radius: math.div($image-container-width, 2);
 	}
 
 	.image {
@@ -113,7 +119,7 @@ p.first {
 		padding-top: 2 * $avatar-border-width;
 		min-height: $image-container-width;
 
-		.name { @extend .h3; margin-top: 0; }
+		.name { margin-top: 0; font-size: 1.25rem; }
 		.title { font-size: 0.9em; margin-bottom: 0.5em; }
 		.bio { font-size: 0.8em; font-style: italic; }
 	}

--- a/css/_content.scss
+++ b/css/_content.scss
@@ -1,3 +1,6 @@
+@use "sass:color";
+@use "variables" as *;
+
 .page-title {
 	z-index: 50;
 	position: relative;
@@ -7,15 +10,16 @@
 .other-things {
 	margin-top: 4rem;
 	color: silver;
-	@extend .small;
-	@extend .fainted;
+	font-size: 0.8em;
+	a { color: $accent-color }
+	a:hover { color: color.adjust($accent-color, $lightness: -18%) }
 }
 
 $a-n-border-width: 0.5rem;
 $a-n-horizontal-margin: -1.5rem;
 $a-n-horizontal-padding: ($a-n-horizontal-margin * -1) - $a-n-border-width;
 .important-notification {
-	border: $a-n-border-width solid lighten($faded-accent-color, 8%);
+	border: $a-n-border-width solid color.adjust($faded-accent-color, $lightness: 8%);
 	padding: $a-n-horizontal-padding;
 	margin: 0 0 3rem 0;
 	position: relative;

--- a/css/_hyde.scss
+++ b/css/_hyde.scss
@@ -31,6 +31,8 @@
  * Update the foundational and global aspects of the page.
  */
 
+@use "variables" as *;
+
 html {
   font-family: "PT Sans", Helvetica, Arial, sans-serif;
 }

--- a/css/_sidebar-adjustements.scss
+++ b/css/_sidebar-adjustements.scss
@@ -1,5 +1,7 @@
+@use "variables" as *;
+
 /*
-  $desktop-threshold in styles.scss is also related to these!
+  $desktop-threshold in _variables.scss is also related to these!
 */
 
 @media #{$desktop-threshold} {

--- a/css/_simple-sharing-buttons.scss
+++ b/css/_simple-sharing-buttons.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $share-img-height: 32px;
 
 .share-buttons {
@@ -8,6 +10,6 @@ $share-img-height: 32px;
 .share-button {
 	display: inline-block;
 	margin: 0;
-	margin-left: $share-img-height / 10;
+	margin-left: math.div($share-img-height, 10);
 	margin-bottom: calc((#{$share-img-height} - 1em) / -2)
 }

--- a/css/_theme.scss
+++ b/css/_theme.scss
@@ -1,6 +1,5 @@
-$accent-color: #F2CB52;
-$faded-accent-color: darken($accent-color, 28%);
-$text-color-on-accent: white;
+@use "sass:color";
+@use "variables" as *;
 
 .sidebar {
 	background-color: $accent-color;
@@ -12,12 +11,12 @@ $text-color-on-accent: white;
 }
 .content a,
 .related-posts li a:hover {
-  color: darken($accent-color, 18%);
+  color: color.adjust($accent-color, $lightness: -18%);
 }
 
 .fainted {
 	a { color: $accent-color }
-	a:hover { color: darken($accent-color, 18%) }
+	a:hover { color: color.adjust($accent-color, $lightness: -18%) }
 }
 
 .sidebar-about {
@@ -29,7 +28,7 @@ $text-color-on-accent: white;
 		margin: -0.35em 0 0.5rem 0.5rem;
 	}
 	.tagline {
-		@extend .small;
+		font-size: 0.8em;
 		margin: 0 0 1rem 0;
 	}
 }

--- a/css/_variables.scss
+++ b/css/_variables.scss
@@ -1,0 +1,6 @@
+@use "sass:color";
+
+$desktop-threshold: "(min-width: 48em) and (min-height: 530px)";
+$accent-color: #F2CB52;
+$faded-accent-color: color.adjust($accent-color, $lightness: -28%);
+$text-color-on-accent: white;

--- a/css/forms.scss
+++ b/css/forms.scss
@@ -1,7 +1,7 @@
 ---
 ---
 
-@import "purecss-forms-min";
+@use "purecss-forms-min";
 
 .contact-form-part {
 	margin-bottom: 1em;

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -1,18 +1,17 @@
 ---
 ---
 
-$desktop-threshold: "(min-width: 48em) and (min-height: 530px)";
-
-@import "poole";
-@import "syntax";
-@import "hyde";
-@import "fonts";
-@import "icon-fonts";
-@import "typography";
-@import "theme";
-@import "blog";
-@import "images";
-@import "content";
-@import "navigation";
-@import "simple-sharing-buttons";
-@import "sidebar-adjustements";
+@use "variables";
+@use "poole";
+@use "syntax";
+@use "hyde";
+@use "fonts";
+@use "icon-fonts";
+@use "typography";
+@use "theme";
+@use "blog";
+@use "images";
+@use "content";
+@use "navigation";
+@use "simple-sharing-buttons";
+@use "sidebar-adjustements";


### PR DESCRIPTION
Migrate from @import to @use/@forward, replace deprecated color functions (darken/lighten → color.adjust), replace slash division (/ → math.div), and inline @extend calls that can't cross @use module boundaries.

Shared variables moved to new css/_variables.scss.